### PR TITLE
fix issue where doc.selectedText sometimes misses entire line of text

### DIFF
--- a/googleDocsUtil.js
+++ b/googleDocsUtil.js
@@ -194,6 +194,7 @@ export default (function () {
       letterSpans.push(textNode);
       container.appendChild(textNode);
     }
+    container.style.whiteSpace = "nowrap";
     simulateElement.appendChild(container);
 
     // The caret is usually at the edge of the letter, we find the edge we are closest to.


### PR DESCRIPTION
Reference issue: https://github.com/ken107/read-aloud/issues/119

**To reproduce**:
- Open https://docs.google.com/document/d/1BDkc11GygnFv7uSi-V3Mj_7as9Wx3biCFOeRcXeMrHQ/edit
- Select the first 2 lines of the paragraph that begins with "My first step in a successful..."
- Call googleDocsUtil.getDocument().selectedText

**Result**:
The first line of the selected text is missing.

**Cause**:
getLocalCaretIndex() creates a temporary DOM, which includes a span for each letter, in order to calculate where the selection starts and ends.  However, when the line is long, the text is wrapped onto the next line, causing incorrect caret position to be returned.

**Solution**:
Use white-space: nowrap on the temporary DOM element to force all letters to be on one line